### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ VAProgressCircle is a custom loading animation for loading iOS content from 0 to
 
 ## Installation
 
-1. VAProgressCircle can be installed via [Cocoapods](http://cocoapods.org/) by adding `pod 'VAProgressCircle'` to your podfile, or you can manually add `UICountingLabel.h/.m` and `VAProgressCircle.h/.m` into your project.
+1. VAProgressCircle can be installed via [CocoaPods](http://cocoapods.org/) by adding `pod 'VAProgressCircle'` to your podfile, or you can manually add `UICountingLabel.h/.m` and `VAProgressCircle.h/.m` into your project.
 2. Either create a VAProgressCircle by using a UIView in your Interface Builder, subclassing it to VAProgressCircle, and linking it up to a property in your UIViewController or by using `- (id)initWithFrame:(CGRect)frame`
 
     ```


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
